### PR TITLE
Add sort/filter FAB to library tracks tab

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -107,7 +107,7 @@ function TabHeader({ currentTabId }: { readonly currentTabId: TabId }) {
 			<IconButton
 				icon={() => <Icon as={SettingsIcon} size={22} color={colors.onSurfaceVariant} />}
 				onPress={() => router.push('/settings')}
-				accessibilityLabel="Settings"
+				accessibilityLabel={'Settings'}
 			/>
 			<Text
 				variant={'headlineMedium'}

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -13,6 +13,7 @@ import {
 	AlbumList,
 	LibrarySortFilterSheet,
 } from '@/src/components/library';
+import { SortFilterFAB } from '@/src/components/sort-filter/sort-filter-fab';
 import { useLibraryFilter } from '@/src/hooks/use-library-filter';
 import { useTabShadow } from '@/src/hooks/use-tab-shadow';
 import { useAppTheme } from '@/lib/theme';
@@ -50,7 +51,9 @@ export default function HomeScreen() {
 	const {
 		tracks: filteredTracks,
 		hasFilters,
+		filterCount,
 		isFilterSheetOpen,
+		openFilterSheet,
 		closeFilterSheet,
 	} = useLibraryFilter();
 
@@ -114,6 +117,10 @@ export default function HomeScreen() {
 					</Tabs>
 				</TabsProvider>
 			</View>
+
+			{tabIndex === 0 && (
+				<SortFilterFAB filterCount={filterCount} onPress={openFilterSheet} />
+			)}
 
 			<LibrarySortFilterSheet isOpen={isFilterSheetOpen} onClose={closeFilterSheet} />
 		</PageLayout>

--- a/app/(tabs)/library.tsx
+++ b/app/(tabs)/library.tsx
@@ -13,7 +13,7 @@ import {
 	AlbumList,
 	LibrarySortFilterSheet,
 } from '@/src/components/library';
-import { SortFilterFAB } from '@/src/components/sort-filter/sort-filter-fab';
+import { SortFilterFAB } from '@/src/components/sort-filter';
 import { useLibraryFilter } from '@/src/hooks/use-library-filter';
 import { useTabShadow } from '@/src/hooks/use-tab-shadow';
 import { useAppTheme } from '@/lib/theme';

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
 				"@shopify/flash-list": "^2.2.0",
 				"audio-equalizer": "file:./modules/audio-equalizer",
 				"audio-metadata": "file:./modules/audio-metadata",
-				"audio-visualizer": "file:./modules/audio-visualizer",
 				"babel-plugin-transform-import-meta": "^2.3.3",
 				"buffer": "^6.0.3",
 				"event-target-shim": "^6.0.2",
@@ -117,6 +116,7 @@
 		},
 		"modules/audio-visualizer": {
 			"version": "1.0.0",
+			"extraneous": true,
 			"peerDependencies": {
 				"expo": "*",
 				"react": "*",
@@ -8086,10 +8086,6 @@
 		},
 		"node_modules/audio-metadata": {
 			"resolved": "modules/audio-metadata",
-			"link": true
-		},
-		"node_modules/audio-visualizer": {
-			"resolved": "modules/audio-visualizer",
 			"link": true
 		},
 		"node_modules/available-typed-arrays": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@shopify/flash-list": "^2.2.0",
 				"audio-equalizer": "file:./modules/audio-equalizer",
 				"audio-metadata": "file:./modules/audio-metadata",
+				"audio-visualizer": "file:./modules/audio-visualizer",
 				"babel-plugin-transform-import-meta": "^2.3.3",
 				"buffer": "^6.0.3",
 				"event-target-shim": "^6.0.2",
@@ -116,7 +117,6 @@
 		},
 		"modules/audio-visualizer": {
 			"version": "1.0.0",
-			"extraneous": true,
 			"peerDependencies": {
 				"expo": "*",
 				"react": "*",
@@ -8086,6 +8086,10 @@
 		},
 		"node_modules/audio-metadata": {
 			"resolved": "modules/audio-metadata",
+			"link": true
+		},
+		"node_modules/audio-visualizer": {
+			"resolved": "modules/audio-visualizer",
 			"link": true
 		},
 		"node_modules/available-typed-arrays": {

--- a/src/application/state/bootstrap-progress-store.ts
+++ b/src/application/state/bootstrap-progress-store.ts
@@ -34,8 +34,7 @@ export const useBootstrapProgressStore = create<BootstrapProgressState>((set) =>
 export const useBootstrapProgress = () =>
 	useBootstrapProgressStore((state) => state.currentStep / state.totalSteps);
 
-export const useBootstrapMessage = () =>
-	useBootstrapProgressStore((state) => state.message);
+export const useBootstrapMessage = () => useBootstrapProgressStore((state) => state.message);
 
 export function getBootstrapProgressState() {
 	return useBootstrapProgressStore.getState();

--- a/src/components/player/progress-bar.tsx
+++ b/src/components/player/progress-bar.tsx
@@ -10,7 +10,7 @@ import { Skeleton } from '@/src/components/ui/skeleton';
 import { ProgressTrack } from '@/src/components/ui/progress-track';
 import { usePlayer } from '@/src/hooks/use-player';
 import { Duration } from '@/src/domain/value-objects/duration';
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { usePlayerTheme } from '@/src/components/player/player-theme-context';
 import { useProgressBarStyle } from '@/src/application/state/settings-store';
 
@@ -22,25 +22,18 @@ export function ProgressBar({ seekable = true }: ProgressBarProps) {
 	const { position, duration, seekTo, isLoading, isBuffering, isPlaying } = usePlayer();
 	const { colors } = usePlayerTheme();
 	const barStyle = useProgressBarStyle();
-	const [isSeeking, setIsSeeking] = useState(false);
-	const [seekPosition, setSeekPosition] = useState(0);
-
 	const totalMillis = duration.totalMilliseconds;
-	const currentMillis = isSeeking ? seekPosition : position.totalMilliseconds;
-	const progress = totalMillis > 0 ? currentMillis / totalMillis : 0;
+	const progress = totalMillis > 0 ? position.totalMilliseconds / totalMillis : 0;
 
 	const handleSeek = useCallback(
 		async (newProgress: number) => {
 			const newPositionMs = Math.round(newProgress * totalMillis);
-			setIsSeeking(false);
 			await seekTo(Duration.fromMilliseconds(newPositionMs));
 		},
 		[totalMillis, seekTo]
 	);
 
-	const currentTime = isSeeking
-		? Duration.fromMilliseconds(seekPosition).format()
-		: position.format();
+	const currentTime = position.format();
 	const totalTime = duration.format();
 
 	const isDisabled = !seekable || isLoading || duration.isZero();

--- a/src/components/selection/batch-action-bar.tsx
+++ b/src/components/selection/batch-action-bar.tsx
@@ -9,7 +9,6 @@ import { memo, useMemo } from 'react';
 import { View, StyleSheet, Pressable } from 'react-native';
 import { PlayerAwareScrollView } from '@/src/components/ui/player-aware-scroll-view';
 import { Text, Surface } from 'react-native-paper';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { FadeInDown, FadeOutDown } from 'react-native-reanimated';
 import {
 	Download,
@@ -140,8 +139,6 @@ function _getActionsForContext(
 export const BatchActionBar = memo(function BatchActionBar(props: BatchActionBarProps) {
 	const { context, selectedCount, onCancel, isProcessing = false } = props;
 	const { colors } = useAppTheme();
-	const insets = useSafeAreaInsets();
-
 	const actions = useMemo(() => _getActionsForContext(context, props), [context, props]);
 
 	if (selectedCount === 0) {

--- a/src/components/settings/progress-style-picker.tsx
+++ b/src/components/settings/progress-style-picker.tsx
@@ -64,14 +64,21 @@ const StyleCard = memo(function StyleCard({
 				{
 					borderColor: isSelected ? colors.primary : colors.outlineVariant,
 					borderWidth: isSelected ? 2 : 1,
-					backgroundColor: pressed ? colors.surfaceContainerHighest : colors.surfaceContainerLow,
+					backgroundColor: pressed
+						? colors.surfaceContainerHighest
+						: colors.surfaceContainerLow,
 				},
 			]}
 		>
-			<View style={[styles.previewContainer, {
-				marginTop: style === 'expressive-variant' ? 14 : 0,
-				marginBottom: style === 'expressive-variant' ? 14 : 0
-			}]}>
+			<View
+				style={[
+					styles.previewContainer,
+					{
+						marginTop: style === 'expressive-variant' ? 14 : 0,
+						marginBottom: style === 'expressive-variant' ? 14 : 0,
+					},
+				]}
+			>
 				<ProgressTrack
 					variant={style}
 					progress={PREVIEW_PROGRESS}

--- a/src/components/ui/animated-splash.tsx
+++ b/src/components/ui/animated-splash.tsx
@@ -249,7 +249,9 @@ export function AnimatedSplash({
 					</View>
 				</View>
 				<View style={styles.progressSection}>
-					<View style={[styles.progressTrack, { backgroundColor: colors.surfaceVariant }]}>
+					<View
+						style={[styles.progressTrack, { backgroundColor: colors.surfaceVariant }]}
+					>
 						<View
 							style={[
 								styles.progressFill,

--- a/src/components/ui/progress-track.tsx
+++ b/src/components/ui/progress-track.tsx
@@ -331,11 +331,7 @@ export function ProgressTrack({
 			<Animated.View
 				style={[
 					thumbAnimatedStyle,
-					isBasic
-						? styles.basicThumb
-						: isVariant
-							? styles.variantThumb
-							: styles.thumb,
+					isBasic ? styles.basicThumb : isVariant ? styles.variantThumb : styles.thumb,
 					{
 						left:
 							activeEnd -
@@ -447,9 +443,7 @@ function renderTrack(style: ProgressBarStyle, params: TrackRenderParams) {
 		return (
 			<Svg width={trackWidth} height={VARIANT_TRACK_HEIGHT} style={styles.variantTrackSvg}>
 				{/* Inactive track (right of thumb) */}
-				{inactivePath.length > 0 && (
-					<Path d={inactivePath} fill={inactiveColor} />
-				)}
+				{inactivePath.length > 0 && <Path d={inactivePath} fill={inactiveColor} />}
 				{/* Active track (left of thumb) */}
 				{activeEnd > 0 && (
 					<Path

--- a/src/components/unified-search/unified-filter-sheet.tsx
+++ b/src/components/unified-search/unified-filter-sheet.tsx
@@ -72,7 +72,12 @@ export function UnifiedFilterSheet({
 				onToggle: onToggleDownloaded,
 			},
 		],
-		[activeFilters.favoritesOnly, activeFilters.downloadedOnly, onToggleFavorites, onToggleDownloaded]
+		[
+			activeFilters.favoritesOnly,
+			activeFilters.downloadedOnly,
+			onToggleFavorites,
+			onToggleDownloaded,
+		]
 	);
 
 	const headerContent = useMemo(

--- a/src/domain/utils/search-filtering.ts
+++ b/src/domain/utils/search-filtering.ts
@@ -113,11 +113,7 @@ export function countActiveSearchFilters(filters: SearchFilters): number {
 }
 
 export function hasActiveUnifiedFilters(filters: UnifiedSearchFilters): boolean {
-	return (
-		filters.contentType !== 'all' ||
-		filters.downloadedOnly ||
-		hasBaseActiveFilters(filters)
-	);
+	return filters.contentType !== 'all' || filters.downloadedOnly || hasBaseActiveFilters(filters);
 }
 
 export function countActiveUnifiedFilters(filters: UnifiedSearchFilters): number {

--- a/src/hooks/use-unified-search.ts
+++ b/src/hooks/use-unified-search.ts
@@ -133,12 +133,7 @@ export function useUnifiedSearch() {
 		}
 
 		return [...downloadedLibraryTracks, ...nonLibraryDownloads];
-	}, [
-		allTracks,
-		filterState.activeFilters.downloadedOnly,
-		downloadedIds,
-		downloadedTracksMap,
-	]);
+	}, [allTracks, filterState.activeFilters.downloadedOnly, downloadedIds, downloadedTracksMap]);
 
 	const libraryFiltersForSearch = useMemo(
 		() => ({
@@ -194,12 +189,7 @@ export function useUnifiedSearch() {
 
 	const libraryTracks = useMemo(() => {
 		if (!hasQuery) return [];
-		const filtered = filterTracks(
-			libraryBaseTracks,
-			query,
-			libraryFiltersForSearch,
-			favorites
-		);
+		const filtered = filterTracks(libraryBaseTracks, query, libraryFiltersForSearch, favorites);
 		return sortTracks(filtered, librarySortField, filterState.sortDirection);
 	}, [
 		libraryBaseTracks,


### PR DESCRIPTION
## Description

Adds a floating action button (FAB) for sort and filter functionality to the library tracks tab. The FAB displays the current filter count and opens the sort/filter sheet when pressed. It only appears on the tracks tab (tabIndex === 0).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes

- Import new `SortFilterFAB` component from `@/src/components/sort-filter/sort-filter-fab`
- Extract `filterCount` and `openFilterSheet` from `useLibraryFilter` hook
- Conditionally render `SortFilterFAB` on the tracks tab with filter count badge and sheet trigger

## Testing

- [ ] Unit tests pass (`npm run test:run`)
- [ ] Type checking passes (`npx tsc --noEmit`)
- [ ] Linting passes (`npm run lint`)
- [ ] Format check passes (`npm run format:check`)

## Checklist

- [ ] My code follows the project's architecture guidelines
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings or errors

https://claude.ai/code/session_01RFamJdhkBTRdPnM5Fbvi3C