### PR TITLE
ci: exclude package-lock.json from prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,5 +5,6 @@ build
 android
 ios
 *.lock
+package-lock.json
 .claude
 .profiling


### PR DESCRIPTION
The Format CI job globs `**/*.json`, which includes the auto-generated `package-lock.json`. npm writes the lockfile in its own style, not Prettier's, so it consistently failed `format:check` — and since `Format` is a required check, it blocked the aggregate `quality-gate`.

After PR #59 aligned the Expo dependencies and greened Lint / Type Check / Test / Expo Doctor / Expo Dependency Check, this lockfile formatting failure was the **last** thing keeping CI red.

`.prettierignore` already excluded `*.lock` but not `package-lock.json`. Added it — lockfiles are generated, not hand-formatted. `npm run format:check` now passes clean.

Fully addresses gap #4 (chronically-red CI): the quality-gate becomes enforceable again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)