### PR TITLE
fix(playback): keep DASH player alive across queue advance in background

### DIFF
--- a/src/application/services/playback-service.ts
+++ b/src/application/services/playback-service.ts
@@ -144,16 +144,21 @@ export class PlaybackService {
 	}
 
 	/**
-	 * Stops the active provider and resolves the audio stream in parallel
-	 * to reduce latency when switching tracks.
+	 * Resolves the audio stream for the next track.
+	 *
+	 * Intentionally does NOT stop the active provider here. Which provider the
+	 * next track needs is only known once the stream URL is resolved, and
+	 * stopping speculatively tears down the current provider's native player
+	 * even when the next track will reuse it (e.g. two consecutive DASH/YouTube
+	 * tracks). The DASH provider keeps its player instance alive across track
+	 * changes for background-playback continuity, so eagerly stopping it here
+	 * would release that player before we know it isn't needed — breaking
+	 * queue advance while the app is backgrounded. See _startPlaybackWithProvider,
+	 * which stops the previous provider only when the provider actually changes.
 	 */
 	private async _resolveStreamForTrack(track: Track): Promise<Result<AudioStream, Error>> {
-		playbackTimer.beginPhase('stop+resolve');
-
-		const stopPromise = this._stopActiveProvider();
-		const streamPromise = this._getAudioStream(track);
-		const [, streamResult] = await Promise.all([stopPromise, streamPromise]);
-
+		playbackTimer.beginPhase('resolve');
+		const streamResult = await this._getAudioStream(track);
 		playbackTimer.endPhase();
 		return streamResult;
 	}
@@ -443,11 +448,6 @@ export class PlaybackService {
 			} catch {}
 		}
 		return null;
-	}
-
-	private async _stopActiveProvider(): Promise<void> {
-		if (!this.activeProvider) return;
-		await this._stopProvider(this.activeProvider);
 	}
 
 	private async _stopProvider(provider: PlaybackProvider): Promise<void> {

--- a/src/plugins/playback/dash/playback-operations.ts
+++ b/src/plugins/playback/dash/playback-operations.ts
@@ -48,9 +48,18 @@ export class PlaybackOperations {
 		headers?: Record<string, string>
 	): AsyncResult<void, Error> {
 		try {
-			this._releasePlayer();
 			this._prepareState(track);
-			this._createPlayer(track, streamUrl, headers);
+			if (this._player) {
+				// Reuse the existing native player instead of releasing and recreating
+				// it. Constructing a brand-new player while the app is backgrounded
+				// does not reliably re-acquire audio focus / the background session,
+				// which is what caused playback to stop after each track ended while
+				// the app was backgrounded. Swapping the source on the live instance
+				// keeps that session intact across track changes.
+				await this._replaceSource(track, streamUrl, headers);
+			} else {
+				this._createPlayer(track, streamUrl, headers);
+			}
 			this._configurePlayer(startPosition);
 			this._emitEvent({ type: 'track-change', track, timestamp: Date.now() });
 			return ok(undefined);
@@ -150,11 +159,9 @@ export class PlaybackOperations {
 		this._updateStatus('loading');
 	}
 
-	private _createPlayer(track: Track, streamUrl: string, headers?: Record<string, string>): void {
+	private _buildSource(track: Track, streamUrl: string, headers?: Record<string, string>) {
 		const contentType = resolveContentType(streamUrl);
-		logger.debug('Creating video player', contentType);
-
-		this._player = createVideoPlayer({
+		return {
 			uri: streamUrl,
 			contentType,
 			metadata: {
@@ -163,7 +170,22 @@ export class PlaybackOperations {
 				artwork: getArtworkUrl(track),
 			},
 			...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
-		});
+		};
+	}
+
+	private _createPlayer(track: Track, streamUrl: string, headers?: Record<string, string>): void {
+		logger.debug('Creating video player', resolveContentType(streamUrl));
+		this._player = createVideoPlayer(this._buildSource(track, streamUrl, headers));
+	}
+
+	private async _replaceSource(
+		track: Track,
+		streamUrl: string,
+		headers?: Record<string, string>
+	): Promise<void> {
+		if (!this._player) return;
+		logger.debug('Replacing video player source', resolveContentType(streamUrl));
+		await this._player.replaceAsync(this._buildSource(track, streamUrl, headers));
 	}
 
 	private _configurePlayer(startPosition?: Duration): void {


### PR DESCRIPTION
## Summary
- Queued tracks stopped playing once the app was backgrounded: `PlaybackService` unconditionally stopped the active provider before resolving each next track, and the DASH (`expo-video`) provider responded by releasing its native player and constructing a new one. Creating a fresh player while backgrounded doesn't reliably reacquire audio focus, so auto-advance on track-end silently failed until the app was reopened.
- `_resolveStreamForTrack` no longer stops the active provider eagerly — the existing conditional stop in `_startPlaybackWithProvider` (which only stops when the next track needs a different provider) is now the single source of truth.
- The DASH provider's `play()` now reuses its existing `VideoPlayer` via `replaceAsync()` when one is already live, instead of releasing and recreating it on every track change.

## Test plan
- [x] `tsc --noEmit`, `eslint`, `prettier --check` all clean
- [x] Full test suite passes (1227 tests)
- [x] Verified live on a Pixel 9a emulator: played a streamed YouTube/DASH track, seeked near the end, backgrounded the app (confirmed via `dumpsys activity activities` that the launcher held foreground focus throughout), let the track end naturally, and confirmed in logcat the sequence `'ended received - calling skipToNext'` → `'Replacing video player source'` (native player reused, not recreated) → `'Status change: playing'` — all while the app remained backgrounded. Re-foregrounded and confirmed the next track was actively playing.
- [x] Built full release APK locally (`eas build --platform android --profile preview --local`) and installed on a physical Pixel 10a; confirmed working in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)